### PR TITLE
[Feature]: integrate codecov

### DIFF
--- a/.github/actions-rs/grcov.yml
+++ b/.github/actions-rs/grcov.yml
@@ -1,0 +1,19 @@
+source-dir: ./contracts
+binary-path: ./target/debug/
+branch: true
+ignore-not-existing: true
+llvm: true
+filter: covered
+output-type: lcov
+output-path: ./lcov.info
+prefix-dir: /home/user/build/
+excl-start: '#[test]'
+excl-br-start: '#[test]'
+ignore:
+ - "./packages/**"
+ - "./**/lib.rs"
+ - "./**/examples/schema.rs"
+ - "./**/testing/**/*"
+ - "./**/tests.rs"
+ - "./**/querier.rs"
+ - "./**/mock_querier.rs"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,29 @@
+on: [push]
+
+name: Code Coverage
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+        env:
+          CARGO_INCREMENTAL: '0'
+          RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests'
+          RUSTDOCFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests'
+      - id: coverage  
+        uses: actions-rs/grcov@v0.1
+        with:
+         config: actions-rs/grcov.yml 
+      - name: Codecov upload
+        uses: codecov/codecov-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }} 
+          path-to-lcov: ${{ steps.coverage.outputs.report }}

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,29 @@
+codecov:
+  require_ci_to_pass: yes
+
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+
+parsers:
+  gcov:
+    branch_detection:
+      conditional: yes
+      loop: yes
+      method: no
+      macro: no
+
+comment:
+  layout: "reach,diff,flags,files,footer"
+  behavior: default
+  require_changes: no
+  
+ignore:
+  - "./packages/**"
+  - "./**/lib.rs"
+  - "./**/examples/schema.rs"
+  - "./**/testing/**/*"
+  - "./**/tests.rs"
+  - "./**/querier.rs"
+  - "./**/mock_querier.rs"


### PR DESCRIPTION
Introduced code coverage of unit tests with the tool "grcov" and added the required files and github actions and workflows to automatically run the tests and upload code coverage results to the Codecov website.